### PR TITLE
Adding fi-ta-summary-heading new hook class

### DIFF
--- a/packages/tables/resources/views/components/summary/row.blade.php
+++ b/packages/tables/resources/views/components/summary/row.blade.php
@@ -92,7 +92,7 @@
             >
                 @if ($loop->first && (! $extraHeadingColumn) && (! $groupsOnly))
                     <span
-                        class="fi-ta-summary-heading flex px-3 py-4 text-sm font-medium text-gray-950 dark:text-white"
+                        class="fi-ta-summary-row-heading flex px-3 py-4 text-sm font-medium text-gray-950 dark:text-white"
                     >
                         {{ $heading }}
                     </span>

--- a/packages/tables/resources/views/components/summary/row.blade.php
+++ b/packages/tables/resources/views/components/summary/row.blade.php
@@ -44,7 +44,7 @@
         <x-filament-tables::cell
             class="text-sm font-medium text-gray-950 dark:text-white"
         >
-            <span class="px-3 py-4">
+            <span class="fi-ta-summary-row-heading px-3 py-4">
                 {{ $heading }}
             </span>
         </x-filament-tables::cell>

--- a/packages/tables/resources/views/components/summary/row.blade.php
+++ b/packages/tables/resources/views/components/summary/row.blade.php
@@ -92,7 +92,7 @@
             >
                 @if ($loop->first && (! $extraHeadingColumn) && (! $groupsOnly))
                     <span
-                        class="flex px-3 py-4 text-sm font-medium text-gray-950 dark:text-white"
+                        class="fi-ta-summary-heading flex px-3 py-4 text-sm font-medium text-gray-950 dark:text-white"
                     >
                         {{ $heading }}
                     </span>


### PR DESCRIPTION
When using summarize() in TextColumn, a new row inserted below table. To make easy sibling cell with 'Summary' text, I add a new hook class fi-ta-summary-heading.

What do you think ?

